### PR TITLE
Alowing syncing appbar in hard coded panorama.

### DIFF
--- a/Caliburn.Micro.BindableAppBar/AppBarConductor.cs
+++ b/Caliburn.Micro.BindableAppBar/AppBarConductor.cs
@@ -148,6 +148,12 @@ namespace Caliburn.Micro.BindableAppBar {
         }
 
         private void PanoramaOnSelectionChanged(object sender, SelectionChangedEventArgs selectionChangedEventArgs) {
+            var panoramaItem = _panorama.SelectedItem as PanoramaItem;
+            if (panoramaItem != null) {
+                SyncAppBar(_panorama.SelectedItem as DependencyObject);
+                return;
+            }
+
             var viewAware = _panorama.SelectedItem as IViewAware;
 
             if (viewAware != null) {


### PR DESCRIPTION
This pull request allowing syncing appbar, when panorama is hard coded in xaml (Because of bug, when selection is not updated when is filled from itemsource)

Example:

```
        <controls:Panorama
            Title="pan tests"
            x:Name="ViewModels"
            cal:Message.Attach="[Event SelectionChanged] = [Action SelectionChanged($this.SelectedIndex)];[Event Loaded] = [Action SelectionChanged($this.SelectedIndex)]">
            <controls:PanoramaItem
                DataContext="{Binding Items[0]}"
                cal:Bind.Model="{Binding}">
                <local:Item1View
                    cal:Bind.Model="{Binding}" />
            </controls:PanoramaItem>

            <controls:PanoramaItem
                DataContext="{Binding Items[1]}">
                <local:Item3View
                    cal:Bind.Model="{Binding}"  />
            </controls:PanoramaItem>

            <controls:PanoramaItem
                DataContext="{Binding Items[2]}">
                <local:Item2View
                    cal:Bind.Model="{Binding}"  />
            </controls:PanoramaItem>

            <controls:PanoramaItem
                DataContext="{Binding Items[3]}">
                <local:Item2View
                    cal:Bind.Model="{Binding}"  />
            </controls:PanoramaItem>

            <controls:PanoramaItem
                DataContext="{Binding Items[4]}">
                <local:Item4View
                    cal:Bind.Model="{Binding}"  />
            </controls:PanoramaItem>

        </controls:Panorama>
```

In the PanoramaOnSelectionChanged event _panoramaSelectedItem is PanoramaItem, instead of ViewModel at current index.

in SelectionChanged/Loaded I activate item at current index.
